### PR TITLE
feat: [002-Signup] 회원가입 및 이메일 인증 비즈니스 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 ### 환경변수 ###
 .env
 
+application-secret.yml
+
+

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     // 이메일 인증 (고민후선택)
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-okhttp'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok:1.18.30'
@@ -56,6 +57,9 @@ dependencies {
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    //랜덤 코드 생성
+    implementation 'org.apache.commons:commons-text:1.10.0'
 }
 
 tasks.named('test') {

--- a/auth-service/src/main/java/com/project/auth/AuthApplication.java
+++ b/auth-service/src/main/java/com/project/auth/AuthApplication.java
@@ -2,7 +2,9 @@ package com.project.auth;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients
 @SpringBootApplication(scanBasePackages = {"com.project.auth","com.project.common"})
 public class AuthApplication {
   public static void main(String[] args){

--- a/auth-service/src/main/java/com/project/auth/application/SignupApplication.java
+++ b/auth-service/src/main/java/com/project/auth/application/SignupApplication.java
@@ -1,0 +1,79 @@
+package com.project.auth.application;
+
+import com.project.auth.client.SendMailForm;
+import com.project.auth.client.mailgun.MailgunClient;
+import com.project.auth.dto.SignupForm;
+import com.project.auth.entity.User;
+import com.project.auth.service.SignupService;
+import com.project.common.exception.CustomException;
+import com.project.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class SignupApplication {
+
+  private final SignupService signupService;
+  private final MailgunClient mailgunClient;
+
+  //배포시 환경변수 재설정
+  @Value("${app.base-url}")
+  private String baseUrl;
+
+  @Value("${mailgun.api.domain}")
+  private String domain;
+
+  //회원가입 메서드
+  @Transactional
+  public String userSignup(SignupForm form) {
+
+    //이메일 중복 검사
+    if (signupService.isEmailExist(form.getEmail())) {
+      throw new CustomException(ErrorCode.ALREADY_REGISTER_EMAIL);
+    }
+    //닉네임 중복 검사
+    if (signupService.isNicknameExist(form.getNickname())) {
+      throw new CustomException(ErrorCode.ALREADY_REGISTER_NICKNAME);
+    }
+
+    // 검사 완료 후 DB에 가입 회원의 정보저장
+    User user = signupService.userSignup(form);
+
+    // mailgun 을 통한 이메일 인증을 위해 랜덤코드 생성
+    String code = signupService.createCode();
+
+    // 랜덤코드를 담은 전송할 검증용 링크 생성
+    String verifyLink = UriComponentsBuilder
+        .fromUriString(baseUrl)
+        .path("/signup/verify")
+        .queryParam("email", form.getEmail())
+        .queryParam("code", code)
+        .toUriString();
+
+    // mailgun 으로 실제 전송할 메일 내용 작성
+    SendMailForm sendMailForm = SendMailForm.builder()
+        .from("FinSight-Social 인증 <postmaster@sandbox4cbc225f64694fff9e4669348b36c4bd.mailgun.org>")
+        .to(form.getEmail())
+        .subject("FinSight-Social Verification Email!")
+        .text(signupService.buildEmailBody(form.getName(), verifyLink))
+        .build();
+
+    // mailgun 을 통해 메일 회원가입 메일 발송
+    mailgunClient.sendEmail(domain, sendMailForm).getBody();
+
+    //DB에 가입유저의 검증코드 저장 및 인증 제한시간 설정
+    signupService.changeUserVerifyInfo(user.getId(), code);
+
+    return "회원가입을 성공적으로 완료하였습니다. 이메일 인증을 진행해주세요.";
+  }
+
+  // 이메일 인증 링크를 누르면 비교를 통한 코드 및 이메일 인증이 실행될 부분
+  public void userVerify(String email, String code) {
+    signupService.verifyEmail(email, code);
+  }
+
+}

--- a/auth-service/src/main/java/com/project/auth/client/SendMailForm.java
+++ b/auth-service/src/main/java/com/project/auth/client/SendMailForm.java
@@ -1,0 +1,17 @@
+package com.project.auth.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class SendMailForm {
+  private String from;
+  private String to;
+  private String subject;
+  private String text;
+}

--- a/auth-service/src/main/java/com/project/auth/client/mailgun/MailgunClient.java
+++ b/auth-service/src/main/java/com/project/auth/client/mailgun/MailgunClient.java
@@ -1,0 +1,19 @@
+package com.project.auth.client.mailgun;
+
+import com.project.auth.client.SendMailForm;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "mailgun", url = "${mailgun.api.base-url}" )
+@Qualifier("mailgun")
+public interface MailgunClient {
+
+  @PostMapping("/{domain}/messages")
+  ResponseEntity<String> sendEmail(
+      @PathVariable String domain,
+      @SpringQueryMap SendMailForm form);
+}

--- a/auth-service/src/main/java/com/project/auth/config/FeignConfig.java
+++ b/auth-service/src/main/java/com/project/auth/config/FeignConfig.java
@@ -1,0 +1,21 @@
+package com.project.auth.config;
+
+import feign.auth.BasicAuthRequestInterceptor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+  @Value("${mailgun.api.key}")
+  private String mailgunKey;
+
+  @Qualifier(value = "mailgun")
+  @Bean
+  public BasicAuthRequestInterceptor basicAuthRequestInterceptor(){
+    return new BasicAuthRequestInterceptor("api",mailgunKey);
+  }
+
+}

--- a/auth-service/src/main/java/com/project/auth/controller/SignupController.java
+++ b/auth-service/src/main/java/com/project/auth/controller/SignupController.java
@@ -1,0 +1,34 @@
+package com.project.auth.controller;
+
+import com.project.auth.application.SignupApplication;
+import com.project.auth.dto.SignupForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/signup")
+@RequiredArgsConstructor
+public class SignupController {
+
+  private final SignupApplication signupApplication;
+
+  @PostMapping
+  public ResponseEntity<String> userSignup(@RequestBody SignupForm form){
+    return ResponseEntity.ok(signupApplication.userSignup(form));
+  }
+
+  @GetMapping("/verify")
+  public ResponseEntity<String> verifyUser(
+      @RequestParam String email,
+      @RequestParam String code
+  ) {
+    signupApplication.userVerify(email, code);
+    return ResponseEntity.ok("성공적으로 인증을 완료하였습니다.");
+  }
+}

--- a/auth-service/src/main/java/com/project/auth/dto/SignupForm.java
+++ b/auth-service/src/main/java/com/project/auth/dto/SignupForm.java
@@ -1,0 +1,21 @@
+package com.project.auth.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SignupForm {
+
+  private String email;
+  private String password;
+  private String name;
+  private String nickname;
+  private LocalDate birth;
+
+}

--- a/auth-service/src/main/java/com/project/auth/entity/User.java
+++ b/auth-service/src/main/java/com/project/auth/entity/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,7 +53,7 @@ public class User {
   private String name;
 
   @Column(nullable = false)
-  private String birth;
+  private LocalDate birth;
 
   @Column(nullable = false)
   private String nickname;

--- a/auth-service/src/main/java/com/project/auth/repository/UserRepository.java
+++ b/auth-service/src/main/java/com/project/auth/repository/UserRepository.java
@@ -1,10 +1,14 @@
 package com.project.auth.repository;
 
 import com.project.auth.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByEmail(String email);
+  Optional<User> findByNickname(String nickname);
 
 }

--- a/auth-service/src/main/java/com/project/auth/service/SignupService.java
+++ b/auth-service/src/main/java/com/project/auth/service/SignupService.java
@@ -1,0 +1,96 @@
+package com.project.auth.service;
+
+import static com.project.common.exception.ErrorCode.ALREADY_VERIFY;
+import static com.project.common.exception.ErrorCode.EXPIRE_CODE;
+import static com.project.common.exception.ErrorCode.NOT_FOUND_USER;
+import static com.project.common.exception.ErrorCode.WRONG_VERIFICATION;
+
+import com.project.auth.dto.SignupForm;
+import com.project.auth.entity.User;
+import com.project.auth.repository.UserRepository;
+import com.project.common.exception.CustomException;
+import com.project.common.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.text.CharacterPredicates;
+import org.apache.commons.text.RandomStringGenerator;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SignupService {
+
+  private final UserRepository userRepository;
+
+  // 클라이언트 입력정보로 부터 회원가입 ( DB 저장 )
+  public User userSignup(SignupForm form) {
+    return userRepository.save(User.builder()
+        .email(form.getEmail().toLowerCase(Locale.ROOT))
+        .password(form.getPassword())
+        .name(form.getName())
+        .birth(form.getBirth())
+        .nickname(form.getNickname().toLowerCase(Locale.ROOT))
+        .emailVerified(false)
+        .build());
+  }
+
+  // 회원 가입시 이메일 중복 검증 (이미 존재하는 이메일의 경우 true 반환)
+  public boolean isEmailExist(String email) {
+    return userRepository.findByEmail(email.toLowerCase(Locale.ROOT))
+        .isPresent();
+  }
+
+  // 회원 가입시 닉네임 중복 검증 (이미 존재하는 닉네임의 경우 true 반환)
+  public boolean isNicknameExist(String nickname) {
+    return userRepository.findByNickname(nickname.toLowerCase(Locale.ROOT))
+        .isPresent();
+  }
+
+  // 이메일 인증 mailgun 메일발송시 포함될 코드 생성 메서드
+  RandomStringGenerator gen = new RandomStringGenerator.Builder()
+      .filteredBy(CharacterPredicates.LETTERS, CharacterPredicates.DIGITS)
+      .build();
+
+  public String createCode() {
+    return gen.generate(10);
+  }
+
+  // 인증 이메일 내용에 들어갈 부분을 작성하는 메서드
+  public String buildEmailBody(String name, String verifyLink) {
+    return new StringBuilder()
+        .append("안녕하세요 ").append(name).append("님!!\n\n")
+        .append("회원가입을 완료하려면 아래 링크를 클릭해 이메일을 인증해 주세요: \n")
+        .append(verifyLink)
+        .toString();
+  }
+
+  //회원가입시 메일인증전 가입된정보에 인증정보를 할당해주는 메서드
+  @Transactional
+  public void changeUserVerifyInfo(Long userId, String code) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+    user.setVerificationCode(code);
+    user.setVerifyExpiredAt(LocalDateTime.now().plusHours(1));
+  }
+
+  // 이메일 인증 링크를 누르면 비교를 통한 코드 및 이메일 인증이 실행될 부분의 실제 비교 로직
+  @Transactional
+  public void verifyEmail(String email, String code) {
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+    // boolean 의 @getter 는 get~ 아니고 is~
+    if (user.isEmailVerified()) {
+      throw new CustomException(ALREADY_VERIFY);
+    } else if (!user.getVerificationCode().equals(code)) {
+      throw new CustomException(WRONG_VERIFICATION);
+    } else if (user.getVerifyExpiredAt().isBefore(LocalDateTime.now())) {
+      throw new CustomException(EXPIRE_CODE);
+    }
+    user.setEmailVerified(true);
+  }
+
+
+}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -1,8 +1,17 @@
 spring:
+  config:
+    import: optional:classpath:application-secret.yml
+
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
+
   datasource:
-    url: jdbc:postgresql://db:5432/finsight
+    url: jdbc:postgresql://localhost:5432/finsight
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
       ddl-auto: update
@@ -10,10 +19,21 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+mailgun:
+  api:
+    base-url: ${mailgun.api.base-url}
+    domain: ${mailgun.api.domain}
+    key:    ${mailgun.api.key}
 
 # 공통 프로퍼티
 server:
   port: 8081
+
+#배포시에는 배포 IP로 할당되도록 변경
+app:
+  base-url: http://localhost:${server.port}
 
 logging:
   level:

--- a/common/src/main/java/com/project/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/project/common/exception/ErrorCode.java
@@ -7,7 +7,15 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-  ALREADY_REGISTER_USER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다.");
+  // 회원가입 관련 예외
+  ALREADY_REGISTER_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일 입니다."),
+  ALREADY_REGISTER_NICKNAME(HttpStatus.BAD_REQUEST, "이미 가입된 닉네임입니다."),
+  NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "인증정보가 일치하는 회원을 찾을 수 없습니다."),
+  ALREADY_VERIFY(HttpStatus.BAD_REQUEST, "이미 인증된 이메일 입니다."),
+  WRONG_VERIFICATION(HttpStatus.BAD_REQUEST, "인증코드가 일치하지 않습니다."),
+  EXPIRE_CODE(HttpStatus.BAD_REQUEST, "인증 제한시간을 초과하였습니다.");
+
+  //
 
   private final HttpStatus httpStatus;
   private final String detail;


### PR DESCRIPTION
Changes
---
- auth-service 모듈의  의존성 및 application.yml을 조금 수정했습니다. 큰 변동사항은 없어서 한번 확인해보시는 정도면 될 것 같습니다. 
- 회원가입 관련 비즈니스 로직을 작성 하였습니다. 
Background
---
- 테스트로 Mailgun 사용 할때 메일 수신 받으려면 미리 mailgun 사이트에 수신 이메일 등록 하셔야합니다. 
그리고 auth-service 모듈에 "application-secret.yml" 파일만드시고 다음과 같은 형식으로 작성해주셔야 합니다. 

mailgun:
  api: 
   base-url: 
   domain: 
   key: 

(각각의 값을 넣어줘야 mailgun 이용이 가능합니다. 각각의 값은 mailgun사이트 회원가입후 방법참조 하시기 바랍니다.) 


