### PR TITLE
feat: [004-Signin] 로그인 기능 개발(Jwt + Spring Security 적용)

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
 
     // Security & JWT
-    //implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/auth-service/src/main/java/com/project/auth/application/SigninApplication.java
+++ b/auth-service/src/main/java/com/project/auth/application/SigninApplication.java
@@ -1,0 +1,28 @@
+package com.project.auth.application;
+
+import static com.project.common.exception.ErrorCode.LOGIN_CHECK_FAIL;
+
+import com.project.auth.dto.SigninForm;
+import com.project.auth.entity.User;
+import com.project.auth.service.SigninService;
+
+import com.project.common.exception.CustomException;
+
+import com.project.common.security.JwtAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SigninApplication {
+
+  private final SigninService signinService;
+  private final JwtAuthenticationProvider provider;
+
+  public String userLoginToken(SigninForm form) {
+    User u = signinService.findValidUser(form.getEmail(), form.getPassword())
+        .orElseThrow(() -> new CustomException(LOGIN_CHECK_FAIL));
+
+    return provider.createToken(u.getEmail(), u.getId(), u.getRole());
+  }
+}

--- a/auth-service/src/main/java/com/project/auth/bootstrap/AdminAccountSeeder.java
+++ b/auth-service/src/main/java/com/project/auth/bootstrap/AdminAccountSeeder.java
@@ -1,0 +1,47 @@
+package com.project.auth.bootstrap;
+
+import com.project.auth.entity.User;
+import com.project.auth.repository.UserRepository;
+import com.project.common.UserRole;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * 실행시 관리자 계정을 만들어주는 시더 입니다.
+ * application.yml 의 환경변수 지정명 보고 각자의 방식으로 알맞게 적용해서 사용하시면 됩니다.
+  */
+
+@Component
+@RequiredArgsConstructor
+public class AdminAccountSeeder implements ApplicationRunner {
+
+  private final UserRepository repo;
+  private final PasswordEncoder pe;
+
+  @Value("${admin.email}")
+  private String adminEmail;
+
+  @Value("${admin.password}")
+  private String adminRawPwd;
+
+  @Override
+  public void run(ApplicationArguments args) {
+    if (!repo.findByEmail(adminEmail).isPresent()) {
+      repo.save(User.builder()
+          .email("admin@yourdomain.com")
+          .password(pe.encode(adminRawPwd))
+          .name("관리자")
+          .nickname("admin")
+          .birth(LocalDate.of(1999,1,1))
+          .emailVerified(true)
+          .role(UserRole.ADMIN)
+          .build());
+    }
+  }
+}

--- a/auth-service/src/main/java/com/project/auth/controller/SigninController.java
+++ b/auth-service/src/main/java/com/project/auth/controller/SigninController.java
@@ -1,0 +1,24 @@
+package com.project.auth.controller;
+
+import com.project.auth.application.SigninApplication;
+import com.project.auth.dto.SigninForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/signin")
+@RequiredArgsConstructor
+public class SigninController {
+
+  private final SigninApplication signinApplication;
+
+  @PostMapping()
+  public ResponseEntity<String> signinUser(@RequestBody SigninForm form) {
+    return ResponseEntity.ok(signinApplication.userLoginToken(form));
+  }
+
+}

--- a/auth-service/src/main/java/com/project/auth/controller/SignupController.java
+++ b/auth-service/src/main/java/com/project/auth/controller/SignupController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("auth/signup")
+@RequestMapping("/signup")
 @RequiredArgsConstructor
 public class SignupController {
 

--- a/auth-service/src/main/java/com/project/auth/dto/SigninForm.java
+++ b/auth-service/src/main/java/com/project/auth/dto/SigninForm.java
@@ -1,0 +1,11 @@
+package com.project.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SigninForm {
+
+  private String email;
+  private String password;
+
+}

--- a/auth-service/src/main/java/com/project/auth/entity/User.java
+++ b/auth-service/src/main/java/com/project/auth/entity/User.java
@@ -1,8 +1,11 @@
 package com.project.auth.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.project.common.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -22,7 +25,7 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
 @Table(
-    name = "User",
+    name = "users",
     uniqueConstraints = {
         @UniqueConstraint(columnNames = "email"),
         @UniqueConstraint(columnNames = "nickname")
@@ -60,6 +63,10 @@ public class User {
 
   @Column(nullable = false)
   private boolean emailVerified;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private UserRole role = UserRole.USER;
 
   @Column(length = 64)
   private String verificationCode;

--- a/auth-service/src/main/java/com/project/auth/service/SigninService.java
+++ b/auth-service/src/main/java/com/project/auth/service/SigninService.java
@@ -1,0 +1,29 @@
+package com.project.auth.service;
+
+
+
+import com.project.auth.entity.User;
+import com.project.auth.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SigninService {
+
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public Optional<User> findValidUser(String email, String rawPassword) {
+    return userRepository.findByEmail(email)
+        .stream()
+        .filter(
+            user -> passwordEncoder.matches(rawPassword, user.getPassword())
+                && user.isEmailVerified()
+        )
+        .findFirst();
+  }
+
+}

--- a/auth-service/src/main/java/com/project/auth/service/SignupService.java
+++ b/auth-service/src/main/java/com/project/auth/service/SignupService.java
@@ -8,6 +8,7 @@ import static com.project.common.exception.ErrorCode.WRONG_VERIFICATION;
 import com.project.auth.dto.SignupForm;
 import com.project.auth.entity.User;
 import com.project.auth.repository.UserRepository;
+import com.project.common.UserRole;
 import com.project.common.exception.CustomException;
 import com.project.common.exception.ErrorCode;
 import java.time.LocalDateTime;
@@ -15,6 +16,7 @@ import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.text.CharacterPredicates;
 import org.apache.commons.text.RandomStringGenerator;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,16 +25,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class SignupService {
 
   private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
 
   // 클라이언트 입력정보로 부터 회원가입 ( DB 저장 )
   public User userSignup(SignupForm form) {
+
+    UserRole role = UserRole.USER; // 클라이언트 입력에 의존하지 않음
+
     return userRepository.save(User.builder()
         .email(form.getEmail().toLowerCase(Locale.ROOT))
-        .password(form.getPassword())
+        // 비밀번호는 암호화 처리해서 저장
+        .password(passwordEncoder.encode(form.getPassword()))
         .name(form.getName())
         .birth(form.getBirth())
         .nickname(form.getNickname().toLowerCase(Locale.ROOT))
         .emailVerified(false)
+        .role(role)
         .build());
   }
 

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -14,18 +14,26 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
+#admin 시더에 들어갈 값들
+admin:
+  email: ${ADMIN_EMAIL}
+  password: ${ADMIN_PW}
+
 mailgun:
   api:
     base-url: ${mailgun.api.base-url}
     domain: ${mailgun.api.domain}
     key:    ${mailgun.api.key}
+
+jwt:
+  secret: ${jwt.secret}
 
 # 공통 프로퍼티
 server:

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,6 +31,12 @@ dependencies {
     // 공통 유틸 및 Bean 관리용 Spring Core
     implementation 'org.springframework:spring-context'
 
+    // jwt 토큰 및 security 관련 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
     // 공통 DTO 직렬화/역직렬화용 Jackson
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 

--- a/common/src/main/java/com/project/common/UserRole.java
+++ b/common/src/main/java/com/project/common/UserRole.java
@@ -1,0 +1,6 @@
+package com.project.common;
+
+public enum UserRole {
+  ADMIN,
+  USER,
+}

--- a/common/src/main/java/com/project/common/UserVo.java
+++ b/common/src/main/java/com/project/common/UserVo.java
@@ -1,0 +1,11 @@
+package com.project.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserVo {
+  private Long id;
+  private String email;
+}

--- a/common/src/main/java/com/project/common/config/SecurityConfig.java
+++ b/common/src/main/java/com/project/common/config/SecurityConfig.java
@@ -1,0 +1,70 @@
+package com.project.common.config;
+
+import com.project.common.security.JwtAuthenticationFilter;
+import com.project.common.security.JwtAuthenticationProvider;
+import com.project.common.security.RestAccessDeniedHandler;
+import com.project.common.security.RestAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.*;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableWebSecurity
+//관리자만 사용할 컨트롤러나 서비스 메서드위에 @PreAuthorize("hasRole('ADMIN')") 이걸 붙이기 위한 어노테이션
+@EnableMethodSecurity(prePostEnabled = true)
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  private final JwtAuthenticationProvider provider;
+  private final RestAuthenticationEntryPoint entryPoint;
+  private final RestAccessDeniedHandler deniedHandler;
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        // API이므로 세션 기반 CSRF 필요 없음
+        .csrf(csrf -> csrf.disable())
+        // 세션 사용하지 않고 JWT만으로 인증
+        .sessionManagement(sm -> sm
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        // 예외 처리 핸들러 적용
+        .exceptionHandling(eh -> eh
+            .authenticationEntryPoint(entryPoint)
+            .accessDeniedHandler(deniedHandler))
+        // 인가 설정 ,로그인·회원가입 엔드포인트는 모두 허용, 나머지 요청은 모두 토큰인증 필요.
+        .authorizeHttpRequests(auth -> auth
+            // 인증 없이 열어줄 경로
+            .requestMatchers(
+                "/signin",
+                "/signup",
+                "/signup/verify",
+                "/swagger-ui/**",
+                "/v3/api-docs/**"
+            ).permitAll()
+            // ADMIN 권한이 필요한 URL
+            .requestMatchers("/admin/**")
+            .hasRole("ADMIN")
+            // 나머지 경로는 모두 로그인 인증 필요
+            .anyRequest().authenticated()
+        )
+        // JwtAuthenticationFilter 를 Spring Security 필터체인에 등록
+        .addFilterBefore(
+            new JwtAuthenticationFilter(provider),
+            UsernamePasswordAuthenticationFilter.class
+        );
+
+    return http.build();
+  }
+}

--- a/common/src/main/java/com/project/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/project/common/exception/ErrorCode.java
@@ -13,9 +13,10 @@ public enum ErrorCode {
   NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "인증정보가 일치하는 회원을 찾을 수 없습니다."),
   ALREADY_VERIFY(HttpStatus.BAD_REQUEST, "이미 인증된 이메일 입니다."),
   WRONG_VERIFICATION(HttpStatus.BAD_REQUEST, "인증코드가 일치하지 않습니다."),
-  EXPIRE_CODE(HttpStatus.BAD_REQUEST, "인증 제한시간을 초과하였습니다.");
+  EXPIRE_CODE(HttpStatus.BAD_REQUEST, "인증 제한시간을 초과하였습니다."),
 
-  //
+  //로그인 관련 예외
+  LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "아이디 또는 패스워드를 확인해 주세요");
 
   private final HttpStatus httpStatus;
   private final String detail;

--- a/common/src/main/java/com/project/common/security/JwtAuthenticationFilter.java
+++ b/common/src/main/java/com/project/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.project.common.security;
+
+import com.project.common.UserVo;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private final JwtAuthenticationProvider provider;
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest req,
+      HttpServletResponse res,
+      FilterChain chain
+  ) throws ServletException, IOException {
+
+    String header = req.getHeader("Authorization");
+
+    if (header != null && header.startsWith("Bearer ")) {
+      String token = header.substring(7);
+
+      if (provider.validateToken(token)) {
+        UserVo user = provider.getUserVo(token);
+
+        List<GrantedAuthority> auths = provider.getRoles(token).stream()
+            .map(role -> new SimpleGrantedAuthority(role))
+            .collect(Collectors.toList());
+
+        UsernamePasswordAuthenticationToken auth =
+            new UsernamePasswordAuthenticationToken(user, null, auths);
+
+        auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+      }
+
+    }
+    chain.doFilter(req, res);
+  }
+}
+

--- a/common/src/main/java/com/project/common/security/JwtAuthenticationProvider.java
+++ b/common/src/main/java/com/project/common/security/JwtAuthenticationProvider.java
@@ -1,0 +1,77 @@
+package com.project.common.security;
+
+import com.project.common.UserRole;
+import com.project.common.UserVo;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtAuthenticationProvider {
+
+  private static final long TOKEN_VALID_TIME = 1000L * 60 * 60 * 24; // 24시간
+
+  private final SecretKey signingKey;
+
+  public JwtAuthenticationProvider(@Value("${jwt.secret}") String secretKey) {
+    this.signingKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+  }
+
+  // 토큰 발급하는 메서드
+  public String createToken(String email, Long id, UserRole role) {
+    Date now = new Date();
+    return Jwts.builder()
+        .setSubject(email)
+        .claim("id", id)
+        .claim("roles", List.of(role.name()))
+        .setIssuedAt(now)
+        .setExpiration(new Date(now.getTime() + TOKEN_VALID_TIME))
+        .signWith(signingKey, SignatureAlgorithm.HS256)
+        .compact();
+  }
+  // 토큰을 받아서 검증하는 메서드
+  public boolean validateToken(String token) {
+    try {
+      Claims claims = Jwts.parserBuilder()
+          .setSigningKey(signingKey)
+          .build()
+          .parseClaimsJws(token)
+          .getBody();
+
+      return !claims.getExpiration().before(new Date());
+    } catch (JwtException | IllegalArgumentException e) {
+      return false;
+    }
+  }
+  // 토큰에서 User 의 id 와 email 을 반환해주는 메서드
+  public UserVo getUserVo(String token) {
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(signingKey)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+
+    Long id = claims.get("id", Long.class);
+    String email = claims.getSubject();
+    return new UserVo(id, email);
+  }
+  // Roles 클레임꺼내는 메서드
+  @SuppressWarnings("unchecked")
+  public List<String> getRoles(String token) {
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(signingKey)
+        .build()
+        .parseClaimsJws(token)
+        .getBody();
+    return claims.get("roles", List.class);
+  }
+}

--- a/common/src/main/java/com/project/common/security/RestAccessDeniedHandler.java
+++ b/common/src/main/java/com/project/common/security/RestAccessDeniedHandler.java
@@ -1,0 +1,25 @@
+package com.project.common.security;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class RestAccessDeniedHandler implements AccessDeniedHandler {
+
+  @Override
+  public void handle(HttpServletRequest request,
+      HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException {
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    String body = String.format(
+        "{\"error\":\"Forbidden\",\"message\":\"%s\"}",
+        accessDeniedException.getMessage()
+    );
+    response.getWriter().write(body);
+  }
+}

--- a/common/src/main/java/com/project/common/security/RestAuthenticationEntryPoint.java
+++ b/common/src/main/java/com/project/common/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package com.project.common.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+  @Override
+  public void commence(HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException) throws IOException {
+    // JSON 응답으로 401 상태코드 와 메시지 반환
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    String body = String.format(
+        "{\"error\":\"Unauthorized\",\"message\":\"%s\"}",
+        authException.getMessage()
+    );
+    response.getWriter().write(body);
+  }
+}

--- a/common/src/main/java/com/project/common/util/GenerateSecretKey.java
+++ b/common/src/main/java/com/project/common/util/GenerateSecretKey.java
@@ -1,0 +1,21 @@
+/**
+ *
+ * jwt secret 키 생성용 프로덕션 클래스.
+ * 사실 제거 해도 무방하지만 일단 공유합니다.
+ * application-secret.yml에 값을 넣어주고 application.yml에서 가져와서 사용하는 방식입니다!
+
+package com.project.common.util;
+
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
+
+public class GenerateSecretKey {
+
+  public static void main(String[] args) {
+    SecretKey key = Keys.secretKeyFor(io.jsonwebtoken.SignatureAlgorithm.HS256);
+    String base64Key = Encoders.BASE64.encode(key.getEncoded());
+    System.out.println("Base64 Secret Key: " + base64Key);
+  }
+}
+*/


### PR DESCRIPTION
- 코드의 흐름은 주석으로 어느정도 표현해놓았습니다. 궁금한게 있으면 회의때 물어보시면 설명해드릴게요! 그리고 각 모듈 메인실행클래스에 @SpringBootApplication(scanBasePackages = {"해당 모듈 패키지 경로","com.project.common"}) 필수입니다! common을 스캔범위에 넣어주세요!
---
Changes
---
- BCryptPasswordEncoder 빈 등록 및 회원가입 시 비밀번호 해싱 적용
- JwtAuthenticationProvider: accessToken/refreshToken 생성·검증, UserVo 및 roles 클레임 추출 메서드 추가
- JwtAuthenticationFilter: Authorization 헤더의 Bearer 토큰 검증 후 SecurityContext에 Authentication 설정
- SecurityConfig: Stateless JWT 보안 설정, /signin, /signup/, Swagger UI 엔드포인트 permitAll, 401/403 예외 처리 핸들러 등록
- UserRole Enum 도입 및 메서드(URL) 단위 권한 분리 (@EnableMethodSecurity, .hasRole("ADMIN") 등)
- AdminAccountSeeder: 애플리케이션 시작 시 관리자 계정 자동 생성 기능 추가