### PR TITLE
fix: [006-Get-Cash-Account] User-Service 모듈에서 데이터 가져오는 방식 수정

### DIFF
--- a/auth-service/src/main/java/com/project/auth/controller/GetUserIdController.java
+++ b/auth-service/src/main/java/com/project/auth/controller/GetUserIdController.java
@@ -1,0 +1,23 @@
+package com.project.auth.controller;
+
+import com.project.auth.service.GetUserIdService;
+import com.project.common.dto.UserIdDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth/users")
+@RequiredArgsConstructor
+public class GetUserIdController {
+
+    private final GetUserIdService getUserIdService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserIdDto> getUserSummary(@PathVariable Long userId) {
+        return ResponseEntity.ok(getUserIdService.getUserId(userId));
+    }
+}

--- a/auth-service/src/main/java/com/project/auth/service/GetUserIdService.java
+++ b/auth-service/src/main/java/com/project/auth/service/GetUserIdService.java
@@ -1,0 +1,23 @@
+package com.project.auth.service;
+
+import com.project.auth.entity.User;
+import com.project.auth.repository.UserRepository;
+import com.project.common.dto.UserIdDto;
+import com.project.common.exception.CustomException;
+import com.project.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserIdService {
+
+    private final UserRepository userRepository;
+
+    public UserIdDto getUserId(Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+
+        return new UserIdDto(user.getId());
+    }
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -20,7 +20,23 @@ jar {
     enabled = true
 }
 
+ext {
+    set('springCloudAwsVersion', "3.3.0")
+}
+
+dependencyManagement {
+    imports {
+        // Spring Cloud AWS BOM
+        mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:${springCloudAwsVersion}"
+    }
+}
+
 dependencies {
+
+    // AWS S3 자동 설정(Starter) + SDK v2
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-s3"
+    implementation "software.amazon.awssdk:s3"
+
     // Lombok
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/common/src/main/java/com/project/common/config/FeignClientConfiguration.java
+++ b/common/src/main/java/com/project/common/config/FeignClientConfiguration.java
@@ -1,0 +1,26 @@
+package com.project.common.config;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignClientConfiguration {
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return template -> {
+            ServletRequestAttributes attributes =
+                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes != null) {
+                HttpServletRequest request = attributes.getRequest();
+                String authHeader = request.getHeader("Authorization");
+                if (authHeader != null) {
+                    template.header("Authorization", authHeader);
+                }
+            }
+        };
+    }
+}

--- a/common/src/main/java/com/project/common/dto/UserIdDto.java
+++ b/common/src/main/java/com/project/common/dto/UserIdDto.java
@@ -1,0 +1,12 @@
+package com.project.common.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserIdDto {
+    private Long userId;
+}

--- a/price-service/build.gradle
+++ b/price-service/build.gradle
@@ -30,7 +30,13 @@ dependencyManagement {
 dependencies {
 
     implementation project(":common")
-    implementation project(':auth-service')
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    // Spring Cloud AWS S3 스타터 (v2 → AWS SDK v2 기반)
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.2"
+    // AWS SDK v2 S3 모듈
+    implementation "software.amazon.awssdk:s3:2.21.20"
+
     // REST API
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/price-service/src/main/java/com/project/PriceApplication.java
+++ b/price-service/src/main/java/com/project/PriceApplication.java
@@ -2,12 +2,10 @@ package com.project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication(scanBasePackages = {"com.project.price","com.project.common"})
-@EnableJpaRepositories(basePackages = {"com.project"})
-@EntityScan(basePackages = {"com.project"})
+@EnableFeignClients(basePackages = "com.project.price.client")
 public class PriceApplication {
     public static void main(String[] args){
             SpringApplication.run(PriceApplication.class, args);

--- a/price-service/src/main/java/com/project/price/client/UserClient.java
+++ b/price-service/src/main/java/com/project/price/client/UserClient.java
@@ -1,0 +1,18 @@
+package com.project.price.client;
+
+import com.project.common.config.FeignClientConfiguration;
+import com.project.common.dto.UserIdDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+        name = "user-service",
+        url = "http://localhost:8081",
+        configuration = FeignClientConfiguration.class
+)
+public interface UserClient {
+
+    @GetMapping("/auth/users/{userId}")
+    UserIdDto getUserId(@PathVariable("userId") Long userId);
+}

--- a/price-service/src/main/java/com/project/price/entity/CashAccount.java
+++ b/price-service/src/main/java/com/project/price/entity/CashAccount.java
@@ -1,6 +1,5 @@
 package com.project.price.entity;
 
-import com.project.auth.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -22,9 +21,8 @@ public class CashAccount {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long AccountId;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
 
     @Column(nullable = false, precision = 15, scale = 2)
     private BigDecimal balance;

--- a/price-service/src/main/java/com/project/price/service/CashAccountService.java
+++ b/price-service/src/main/java/com/project/price/service/CashAccountService.java
@@ -1,9 +1,7 @@
 package com.project.price.service;
 
-import com.project.auth.entity.User;
-import com.project.auth.repository.UserRepository;
-import com.project.common.exception.CustomException;
-import com.project.common.exception.ErrorCode;
+import com.project.common.dto.UserIdDto;
+import com.project.price.client.UserClient;
 import com.project.price.dto.CashAccountDto;
 import com.project.price.entity.CashAccount;
 import com.project.price.repository.CashAccountRepository;
@@ -19,15 +17,14 @@ import java.util.List;
 public class CashAccountService {
 
     private final CashAccountRepository cashAccountRepository;
-    private final UserRepository userRepository;
+    private final UserClient userClient;
 
     //계좌 생성
     public CashAccountDto createAccount(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+        UserIdDto user = userClient.getUserId(userId);
 
         CashAccount account = CashAccount.builder()
-                .user(user)
+                .userId(user.getUserId())
                 .balance(BigDecimal.ZERO)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
@@ -39,7 +36,9 @@ public class CashAccountService {
 
     //계좌 조회
     public List<CashAccountDto> getAccountsByUserId(Long userId) {
-        List<CashAccount> accounts = cashAccountRepository.findAllByUserId(userId);
+        UserIdDto user = userClient.getUserId(userId);
+
+        List<CashAccount> accounts = cashAccountRepository.findAllByUserId(user.getUserId());
         return accounts.stream().map(this::toDto).toList();
     }
 
@@ -47,7 +46,7 @@ public class CashAccountService {
     private CashAccountDto toDto(CashAccount account) {
         return CashAccountDto.builder()
                 .accountId(account.getAccountId())
-                .userId(account.getUser().getId())
+                .userId(account.getUserId())
                 .balance(account.getBalance())
                 .createdAt(account.getCreatedAt().toString())
                 .updatedAt(account.getUpdatedAt().toString())

--- a/price-service/src/main/resources/application.yml
+++ b/price-service/src/main/resources/application.yml
@@ -13,6 +13,20 @@ spring:
       hibernate:
         format_sql: true
 
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: finsight-social-project
+        profile-folder: team-project/profiles
+
 # 공통 프로퍼티
 server:
   port: 8085


### PR DESCRIPTION
### 📌 관련 이슈
- 005-create-cash-account
- 006-get-cash-account

### 🔍 작업 내용

- Entity에는 외부 서비스와 연관관계를 맺지 않고 ID(Long)만 저장한다.
- 공유할 DTO는 common 모듈에 정의하여 모든 서비스가 함께 사용한다.
- 사용자 정보 제공 서비스는 REST API로 DTO를 반환하는 조회 기능을 제공한다.
- 정보를 가져오는 서비스는 FeignClient를 사용해 외부 API를 호출한다.
- Spring Security 환경에서는 Feign 요청에 인증 토큰을 자동으로 포함시킨다.

--------------------------------

자세한 사항은 notion에 적어두었습니다!
