### PR TITLE
feat: [014-AssetMetadata] 종목 메타데이터 수집 구현

### DIFF
--- a/price-service/build.gradle
+++ b/price-service/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation project(":common")
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-slf4j:11.10'
+
 
     // Spring Cloud AWS S3 스타터 (v2 → AWS SDK v2 기반)
     implementation "io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.2"

--- a/price-service/src/main/java/com/project/price/client/FinnhubClient.java
+++ b/price-service/src/main/java/com/project/price/client/FinnhubClient.java
@@ -1,0 +1,24 @@
+package com.project.price.client;
+
+import com.project.price.dto.CompanyProfileDto;
+import com.project.price.dto.QuoteDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "finnhub", url = "${finnhub.base-url}")
+public interface FinnhubClient {
+
+  @GetMapping("/stock/profile2")
+  CompanyProfileDto getProfile(
+      @RequestParam("symbol") String symbol,
+      @RequestParam("token") String apiKey
+  );
+
+  @GetMapping("/quote")
+  QuoteDto getQuote(
+      @RequestParam("symbol") String symbol,
+      @RequestParam("token") String apiKey
+  );
+
+}

--- a/price-service/src/main/java/com/project/price/controller/AssetMetadataController.java
+++ b/price-service/src/main/java/com/project/price/controller/AssetMetadataController.java
@@ -1,0 +1,44 @@
+package com.project.price.controller;
+
+import com.project.price.entity.AssetMetadata;
+import com.project.price.service.AssetMetadataService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/metadata")
+@RequiredArgsConstructor
+public class AssetMetadataController {
+
+  private final AssetMetadataService service;
+
+  /**
+   * 1. 심볼로 회사 메타데이터 조회 (풀텍스트 검색만 가능)
+   *    - DB에 있으면 바로 반환
+   *    - 없으면 API 호출 후 저장 → 반환
+   */
+  @GetMapping("/{symbol}")
+  public ResponseEntity<AssetMetadata> getBySymbol(@PathVariable String symbol) {
+    AssetMetadata meta = service.getOrFetch(symbol);
+    return ResponseEntity.ok(meta);
+  }
+
+  /**
+   * 2. 이름 또는 심볼 키워드로 검색
+   *    - DB에 저장된 종목 중에서만 검색
+   *    - 이 부분은 구현에 대해서 어떻게 구현해야 할지 좀더 고민해볼 필요가 있지만, 일단 DB에 저장되어 있는 회사의 메타 정보들에서만 가죠오는 형태로 구현
+   */
+  @GetMapping("/search")
+  public ResponseEntity<List<AssetMetadata>> search(
+      @RequestParam("q") String keyword
+  ) {
+    List<AssetMetadata> results = service.search(keyword);
+    return ResponseEntity.ok(results);
+  }
+}

--- a/price-service/src/main/java/com/project/price/dto/CompanyProfileDto.java
+++ b/price-service/src/main/java/com/project/price/dto/CompanyProfileDto.java
@@ -1,0 +1,33 @@
+package com.project.price.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompanyProfileDto {
+  private String country;
+  private String currency;
+  private String exchange;
+
+  @JsonProperty("finnhubIndustry")
+  private String finnhubIndustry;
+
+  private String ipo;
+  private String logo;
+
+  @JsonProperty("marketCapitalization")
+  private Long marketCapitalization;
+
+  private String name;
+  private Double shareOutstanding;
+  private String ticker;
+  private String weburl;
+}

--- a/price-service/src/main/java/com/project/price/dto/QuoteDto.java
+++ b/price-service/src/main/java/com/project/price/dto/QuoteDto.java
@@ -1,0 +1,23 @@
+package com.project.price.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuoteDto {
+
+  private double c;   // current price
+  private double d;   // change
+  private double dp;  // percent change
+  private double h;   // high of day
+  private double l;   // low of day
+  private double o;   // open of day
+  private double pc;  // previous close
+}

--- a/price-service/src/main/java/com/project/price/entity/AssetMetadata.java
+++ b/price-service/src/main/java/com/project/price/entity/AssetMetadata.java
@@ -1,0 +1,50 @@
+package com.project.price.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Table(name="asset_metadata")
+@Entity
+@Setter
+@Getter
+public class AssetMetadata {
+
+  @Id
+  @Column(length = 20)
+  private String symbol;            // "005930.KS"
+
+  @Column(nullable = false, length = 100)
+  private String name;              // "Samsung Electronics Co Ltd"
+
+  @Column(length = 50)
+  private String exchange;          // "KRX"
+
+  @Column(length = 50)
+  private String country;           // "KR"
+
+  @Column(length = 50)
+  private String finnhubIndustry;   // "Technology"
+
+  private Long marketCapitalization;      // 500000000000L
+  private Double shareOutstanding;        // 100000000.0
+
+  @Column(length = 200)
+  private String logo;              // URL
+
+  @Column(length = 200)
+  private String weburl;            // Company website
+
+  private LocalDate ipo;            // LocalDate.parse("1970-06-11")
+
+  @UpdateTimestamp
+  private LocalDateTime updatedAt;  // 마지막 갱신 시각
+
+
+}

--- a/price-service/src/main/java/com/project/price/repository/AssetMetaDataRepository.java
+++ b/price-service/src/main/java/com/project/price/repository/AssetMetaDataRepository.java
@@ -1,0 +1,18 @@
+package com.project.price.repository;
+
+import com.project.price.entity.AssetMetadata;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AssetMetaDataRepository extends JpaRepository<AssetMetadata, String> {
+
+  // 키워드로 리스트 검색
+  List<AssetMetadata> findByNameContainingIgnoreCaseOrSymbolContaining(
+      String nameKeyword,
+      String symbolKeyword
+  );
+
+
+}

--- a/price-service/src/main/java/com/project/price/service/AssetMetadataService.java
+++ b/price-service/src/main/java/com/project/price/service/AssetMetadataService.java
@@ -1,0 +1,62 @@
+package com.project.price.service;
+
+
+import com.project.price.client.FinnhubClient;
+import com.project.price.dto.CompanyProfileDto;
+import com.project.price.entity.AssetMetadata;
+import com.project.price.repository.AssetMetaDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AssetMetadataService {
+
+  private final FinnhubClient finnhubClient;
+  private final AssetMetaDataRepository repository;
+
+  @Value("${finnhub.api-key}")
+  private String apiKey;
+
+  /**
+   * DB에 있으면 반환 , 없으면 API 호출 후 저장
+   */
+  public AssetMetadata getOrFetch(String symbol) {
+    return repository.findById(symbol)
+        .orElseGet(() -> fetchAndSave(symbol));
+  }
+
+  /**
+   * 반드시 API 호출 -> 저장(업데이트)
+   */
+  public AssetMetadata fetchAndSave(String symbol) {
+    CompanyProfileDto dto = finnhubClient.getProfile(symbol, apiKey);
+
+    AssetMetadata meta = new AssetMetadata();
+    meta.setSymbol(dto.getTicker());
+    meta.setName(dto.getName());
+    meta.setExchange(dto.getExchange());
+    meta.setCountry(dto.getCountry());
+    meta.setFinnhubIndustry(dto.getFinnhubIndustry());
+    meta.setMarketCapitalization(dto.getMarketCapitalization());
+    meta.setShareOutstanding(dto.getShareOutstanding());
+    meta.setLogo(dto.getLogo());
+    meta.setWeburl(dto.getWeburl());
+    if (dto.getIpo() != null && !dto.getIpo().isBlank()) {
+      meta.setIpo(LocalDate.parse(dto.getIpo()));
+    }
+    //Jpa save에 의해 id로 식별후 중복없이 같은값이면 갱신 아니면 추가 됌.
+    return repository.save(meta);
+  }
+
+  /**
+   * DB에 저장된 종목 중 이름 또는 심볼에 키워드가 포함된 전체 리스트 반환
+   */
+  public List<AssetMetadata> search(String keyword) {
+    return repository.findByNameContainingIgnoreCaseOrSymbolContaining(keyword, keyword);
+  }
+}

--- a/price-service/src/main/resources/application.yml
+++ b/price-service/src/main/resources/application.yml
@@ -15,6 +15,13 @@ spring:
       hibernate:
         format_sql: true
 
+  task:
+    scheduling:
+      pool:
+        size: 5
+      thread-name-prefix: "sched-"
+      timezone: Asia/Seoul
+
   cloud:
     openfeign:
       okhttp:
@@ -40,6 +47,10 @@ server:
 
 jwt:
   secret: ${jwt.secret}
+
+# Finnhub API 호출 기본 URL (키는 secret.yml)
+finnhub:
+  base-url: https://finnhub.io/api/v1
 
 logging:
   level:


### PR DESCRIPTION
Changes
---

- AssetMetadataService.getOrFetch() 로직 추가
- fetchAndSave() 로 Finnhub API 호출 → DB 저장 기능 구현
- AssetMetadataController 에 심볼을 통한 메타데이터 조회 구현
- AssetMetadataRepository, 시세 & 종목매타데이터 DTO 및 엔티티 매핑 완료

---

- application-secret.yml에 각자 가입한 finnhub API키를 넣어주세요!
         