### PR TITLE
feat: [024-Quote] 시세정보 수집 기능 구현 (with Finnhub API)

### DIFF
--- a/common/src/main/java/com/project/common/config/SecurityConfig.java
+++ b/common/src/main/java/com/project/common/config/SecurityConfig.java
@@ -51,7 +51,13 @@ public class SecurityConfig {
         // 인가 설정 ,로그인·회원가입 엔드포인트는 모두 허용, 나머지 요청은 모두 토큰인증 필요.
         .authorizeHttpRequests(auth -> auth
             // 인증 없이 열어줄 경로
-            .requestMatchers(
+
+            // 실시간 시세 테스트용 html, WS 엔드포인트
+            .requestMatchers("/test-ws.html", "/ws/**").permitAll()
+            .requestMatchers("/app/**", "/queue/**").permitAll()
+            .requestMatchers("/api/metadata/**", "/api/quote/**").permitAll()
+
+              .requestMatchers(
                 "/auth/signin",
                 "/auth/signup",
                 "/auth/signup/verify",

--- a/price-service/build.gradle
+++ b/price-service/build.gradle
@@ -55,12 +55,11 @@ dependencies {
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
-
-    // HTML 파싱 (웹 스크래핑용도로 생각중임 변경할수도?)
-    implementation 'org.jsoup:jsoup:1.16.1'
-
     // WebSocket (실시간 시세 푸시)
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // JSON 바인딩 강화
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok:1.18.30'

--- a/price-service/src/main/java/com/project/price/PriceApplication.java
+++ b/price-service/src/main/java/com/project/price/PriceApplication.java
@@ -3,9 +3,11 @@ package com.project.price;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {"com.project.price","com.project.common"})
 @EnableFeignClients(basePackages = "com.project.price.client")
+@EnableScheduling
 public class PriceApplication {
     public static void main(String[] args){
             SpringApplication.run(PriceApplication.class, args);

--- a/price-service/src/main/java/com/project/price/config/WebSocketConfig.java
+++ b/price-service/src/main/java/com/project/price/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.project.price.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.*;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // 클라이언트가 여기로 WS 연결을 시도
+    registry.addEndpoint("/ws/quotes")
+        .setAllowedOriginPatterns("*")
+        .withSockJS();
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    // 클라이언트→서버 메시지는 /app prefix
+    registry.setApplicationDestinationPrefixes("/app");
+    // 서버→클라이언트 푸시는 /queue prefix
+    registry.enableSimpleBroker("/queue");
+    registry.setUserDestinationPrefix("/user");
+  }
+}

--- a/price-service/src/main/java/com/project/price/controller/QuoteController.java
+++ b/price-service/src/main/java/com/project/price/controller/QuoteController.java
@@ -1,0 +1,22 @@
+package com.project.price.controller;
+
+import com.project.price.dto.QuoteDto;
+import com.project.price.service.QuoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/quote")
+@RequiredArgsConstructor
+public class QuoteController {
+  private final QuoteService quoteService;
+
+  @GetMapping("/{symbol}")
+  public ResponseEntity<QuoteDto> getQuote(@PathVariable String symbol) {
+    return ResponseEntity.ok(quoteService.fetchQuote(symbol));
+  }
+}

--- a/price-service/src/main/java/com/project/price/controller/QuoteSubscriptionController.java
+++ b/price-service/src/main/java/com/project/price/controller/QuoteSubscriptionController.java
@@ -1,0 +1,42 @@
+package com.project.price.controller;
+
+import com.project.price.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Controller;
+
+
+@Controller
+@RequiredArgsConstructor
+public class QuoteSubscriptionController {
+
+  private static final Logger log = LoggerFactory.getLogger(QuoteSubscriptionController.class);
+  private final SubscriptionService subscriptionService;
+
+  public static record SubscriptionMsg(String symbol) {}
+
+  /**
+   * 클라이언트가 /app/subscribe 로 보내는 메시지를 처리
+   */
+  @MessageMapping("/subscribe")
+  public void subscribe(SubscriptionMsg msg, SimpMessageHeaderAccessor header) {
+    String sessionId = header.getSessionId();
+    log.info("> [SUBSCRIBE] session={} symbol={}", sessionId, msg.symbol());
+    subscriptionService.subscribe(sessionId, msg.symbol());
+  }
+
+  /**
+   * 클라이언트가 /app/unsubscribe 로 보내는 메시지를 처리
+   * 프론트개발시에는 “뒤로 가기”나 “컴포넌트 언마운트” 시점에 이 /app/unsubscribe를 호출하도록 구현하면 될 것 같습니당.
+   */
+  @MessageMapping("/unsubscribe")
+  public void unsubscribe(SubscriptionMsg msg, SimpMessageHeaderAccessor header) {
+    String sessionId = header.getSessionId();
+    log.info("X [UNSUBSCRIBE] session={} symbol={}", sessionId, msg.symbol());
+    subscriptionService.unsubscribe(sessionId, msg.symbol());
+  }
+}
+

--- a/price-service/src/main/java/com/project/price/scheduler/QuotePusher.java
+++ b/price-service/src/main/java/com/project/price/scheduler/QuotePusher.java
@@ -1,0 +1,54 @@
+package com.project.price.scheduler;
+
+import com.project.price.dto.QuoteDto;
+import com.project.price.service.QuoteService;
+import com.project.price.service.SubscriptionService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class QuotePusher {
+
+  private static final Logger log = LoggerFactory.getLogger(QuotePusher.class);
+  private final SubscriptionService subserv;
+  private final QuoteService quoteserv;
+  private final SimpMessagingTemplate temp;
+
+  private static final long INTERVAL_MS = 15_000L; // 15초
+
+  @Scheduled(fixedDelay = INTERVAL_MS)
+  public void pushQuotes() {
+    log.info("─── pushQuotes 호출 ───");
+    // 모든 활성 세션 ID를 순회
+    for (String sessionId : subserv.getAllSessionIds()) {
+      // 해당 세션이 구독 중인 심볼 목록
+
+      var symbols = subserv.getSubscribed(sessionId);
+      log.info("  session={} 구독목록={}", sessionId, symbols);
+      if (symbols.isEmpty()) {
+        continue;  // 구독 심볼 없으면 건너뜀
+      }
+      // 각 심볼별 실시간 시세 조회
+      Map<String, QuoteDto> payload = symbols.stream()
+          .collect(Collectors.toMap(
+              symbol -> symbol,
+              quoteserv::fetchQuote
+          ));
+      log.info("  session={} 에게 전송 payload={}", sessionId, payload);
+      // 해당 세션으로 전송
+      temp.convertAndSendToUser(
+          sessionId,
+          "/queue/quotes",
+          payload
+      );
+    }
+  }
+}

--- a/price-service/src/main/java/com/project/price/service/QuoteService.java
+++ b/price-service/src/main/java/com/project/price/service/QuoteService.java
@@ -1,0 +1,26 @@
+package com.project.price.service;
+
+
+
+import com.project.price.client.FinnhubClient;
+import com.project.price.dto.QuoteDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuoteService {
+
+  private final FinnhubClient finnhubClient;
+
+  @Value("${finnhub.api-key}")
+  private String apiKey;
+
+  /**
+   * 심볼 하나에 대해 Finnhub에서 실시간 시세를 조회하여 DTO로 반환
+   */
+  public QuoteDto fetchQuote(String symbol) {
+    return finnhubClient.getQuote(symbol, apiKey);
+  }
+}

--- a/price-service/src/main/java/com/project/price/service/SubscriptionService.java
+++ b/price-service/src/main/java/com/project/price/service/SubscriptionService.java
@@ -1,0 +1,50 @@
+package com.project.price.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class SubscriptionService {
+
+  // sessionId → 구독 중인 심볼 집합
+  private final Map<String, Set<String>> subs = new ConcurrentHashMap<>();
+
+  /**
+   * sessionId가 symbol을 구독하도록 등록
+   */
+  public void subscribe(String sessionId, String symbol) {
+    subs
+        .computeIfAbsent(sessionId, id -> ConcurrentHashMap.newKeySet())
+        .add(symbol);
+  }
+
+  /**
+   *  sessionId의 symbol 구독을 해제
+   *
+   */
+  public void unsubscribe(String sessionId, String symbol) {
+    Set<String> set = subs.get(sessionId);
+    if (set != null) {
+      set.remove(symbol);
+      if (set.isEmpty()) {
+        subs.remove(sessionId);
+      }
+    }
+  }
+
+  /**
+   * 해당 sessionId가 구독 중인 심볼 목록 조회
+   */
+  public Set<String> getSubscribed(String sessionId) {
+    return subs.getOrDefault(sessionId, Set.of());
+  }
+
+  /**
+   * 현재 구독 중인 모든 sessionId 조회 */
+  public Set<String> getAllSessionIds() {
+    return subs.keySet();
+  }
+}

--- a/price-service/src/main/resources/application.yml
+++ b/price-service/src/main/resources/application.yml
@@ -14,6 +14,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  # WebSocket 세부 설정
+  websocket:
+    allowed-origins: "*"
 
   task:
     scheduling:

--- a/price-service/src/main/resources/static/test-ws.html
+++ b/price-service/src/main/resources/static/test-ws.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <style>
+    pre#log {
+      background: #f5f5f5;
+      border: 1px solid #ddd;
+      padding: 10px;
+      max-height: 300px;
+      overflow-y: auto;
+      font-family: monospace;
+    }
+  </style>
+  <script src="https://cdn.jsdelivr.net/npm/sockjs-client/dist/sockjs.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/stompjs/lib/stomp.min.js"></script>
+</head>
+<body>
+<h3>WebSocket Test</h3>
+<pre id="log"></pre>
+<script>
+  const log = txt => document.getElementById('log').innerText += txt + '\n';
+
+  // 1. SockJS로 연결
+  const sock = new SockJS('/ws/quotes');
+  const client = Stomp.over(sock);
+
+  client.connect({}, frame => {
+    log('Connected: ' + frame);
+
+    // 2. 구독: 서버 푸시 받을 채널
+    client.subscribe('/user/queue/quotes', msg => {
+      log('Push: ' + msg.body);
+    });
+
+    // 3. 구독 요청: 서버에 내 심볼을 알려줌
+    client.send('/app/subscribe', {}, JSON.stringify({ symbol: 'AAPL' }));
+    log('Sent subscribe for AAPL');
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Changes

- QuoteController 추가
- QuoteService 추가
- symbol(티커)을 통해 개발 시세의 각 정보 Finnhub에서 호출(저장x)
---
Todo

- 시세정보를 가능한선에서 짧은주기로 계속 받아올수있도록 구현.
---
Background

- 종목 메타데이터와 시세를 어떤형태로 가져올것인지는 여기까지의 개발로도 확인할수있습니다! 개발하시는 기능에서 정보가 필요하시다면 엔티티클래스와 finnhub의 API 문서를 참고해주세요!