### PR TITLE
feat: [033-User-Search] 유저 검색

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // Elasticsearch
+    implementation 'co.elastic.clients:elasticsearch-java:8.15.5'
+
     //랜덤 코드 생성
     implementation 'org.apache.commons:commons-text:1.10.0'
 }

--- a/auth-service/src/main/java/com/project/auth/controller/UserMigrationController.java
+++ b/auth-service/src/main/java/com/project/auth/controller/UserMigrationController.java
@@ -1,0 +1,28 @@
+package com.project.auth.controller;
+
+import com.project.auth.service.UserMigrationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/migrate")
+public class UserMigrationController {
+
+    private final UserMigrationService userMigrationService;
+
+    //유저 마이그레이션
+    @PostMapping("/users")
+    public String migrateUsers() {
+        try {
+            userMigrationService.migrateUsersToElasticsearch();
+            return "Migration success";
+        } catch (IOException e) {
+            return "Migration failed";
+        }
+    }
+}

--- a/auth-service/src/main/java/com/project/auth/service/UserDocumentMapper.java
+++ b/auth-service/src/main/java/com/project/auth/service/UserDocumentMapper.java
@@ -1,0 +1,13 @@
+package com.project.auth.service;
+
+import com.project.auth.entity.User;
+import com.project.common.elasticsearch.UserDocument;
+
+public class UserDocumentMapper {
+    public static UserDocument fromEntity(User user) {
+        return UserDocument.builder()
+                .id(user.getId())
+                .username(user.getNickname())
+                .build();
+    }
+}

--- a/auth-service/src/main/java/com/project/auth/service/UserMigrationService.java
+++ b/auth-service/src/main/java/com/project/auth/service/UserMigrationService.java
@@ -1,0 +1,34 @@
+package com.project.auth.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.project.auth.entity.User;
+import com.project.auth.repository.UserRepository;
+import com.project.common.config.ElasticsearchConfig;
+import com.project.common.elasticsearch.UserDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserMigrationService {
+
+    private final UserRepository userRepository;
+    private final ElasticsearchClient elasticsearchClient;
+
+    //유저 마이그레이션
+    public void migrateUsersToElasticsearch() throws IOException {
+        List<User> allUsers = userRepository.findAll();
+
+        for (User user : allUsers) {
+            UserDocument doc = UserDocumentMapper.fromEntity(user);
+            elasticsearchClient.index(i -> i
+                    .index("users")
+                    .id(String.valueOf(doc.getId()))
+                    .document(doc)
+            );
+        }
+    }
+}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -60,6 +60,9 @@ dependencies {
     // @ControllerAdvice 기반 GlobalExceptionHandler를 위해 Spring Web 제공
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // Elasticsearch
+    implementation 'co.elastic.clients:elasticsearch-java:8.15.5'
+
     // Test utilities
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/common/src/main/java/com/project/common/config/ElasticsearchConfig.java
+++ b/common/src/main/java/com/project/common/config/ElasticsearchConfig.java
@@ -1,0 +1,33 @@
+package com.project.common.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ElasticsearchConfig {
+
+    // Elasticsearch의 Low-level REST 클라이언트 빈 생성
+    @Bean
+    public RestClient restClient() {
+        return RestClient.builder(
+                new HttpHost("localhost", 9200)
+        ).build();
+    }
+
+    // Elasticsearch Java API 클라이언트 빈 생성
+    @Bean
+    public ElasticsearchClient elasticsearchClient(RestClient restClient) {
+        // HTTP 요청을 JSON으로 직렬화/역직렬화
+        // Jackson 기반 JSON 직렬화
+        RestClientTransport transport = new RestClientTransport(
+                restClient,
+                new JacksonJsonpMapper()
+        );
+        return new ElasticsearchClient(transport);
+    }
+}

--- a/common/src/main/java/com/project/common/config/SecurityConfig.java
+++ b/common/src/main/java/com/project/common/config/SecurityConfig.java
@@ -63,7 +63,9 @@ public class SecurityConfig {
                 "/auth/signup/verify",
                 "/auth/refresh",
                 "/swagger-ui/**",
-                "/v3/api-docs/**"
+                "/v3/api-docs/**",
+                "/admin/**",
+                "/migrate/**"
             ).permitAll()
             // 로그아웃
             .requestMatchers("/auth/logout")

--- a/common/src/main/java/com/project/common/elasticsearch/UserDocument.java
+++ b/common/src/main/java/com/project/common/elasticsearch/UserDocument.java
@@ -1,0 +1,11 @@
+package com.project.common.elasticsearch;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class UserDocument {
+    private Long id;
+    private String username;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,24 @@ services:
     networks:
       - finsight-network
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.0
+    container_name: finsight-es
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    networks:
+      - finsight-network
+
 volumes:
   db-data:
+  es-data:
 
 networks:
   finsight-network:

--- a/sns-service/build.gradle
+++ b/sns-service/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.webjars:sockjs-client:1.5.1'
     implementation 'org.webjars:stomp-websocket:2.3.4'
+
+    // Elasticsearch
+    implementation 'co.elastic.clients:elasticsearch-java:8.15.5'
 }
 
 tasks.named('test') {

--- a/sns-service/src/main/java/com/project/sns/controller/IndexAdminController.java
+++ b/sns-service/src/main/java/com/project/sns/controller/IndexAdminController.java
@@ -1,0 +1,27 @@
+package com.project.sns.controller;
+
+import com.project.sns.service.IndexAdminService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class IndexAdminController {
+
+    private final IndexAdminService indexAdminService;
+
+    //Elasticsearch 유저 인덱싱
+    @PostMapping("/create-users-index")
+    public ResponseEntity<String> createUsersIndex() {
+        try {
+            indexAdminService.createUsersIndex();
+            return ResponseEntity.ok("users 인덱스 생성 성공!");
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body("users 인덱스 생성 실패: " + e.getMessage());
+        }
+    }
+}

--- a/sns-service/src/main/java/com/project/sns/controller/SearchController.java
+++ b/sns-service/src/main/java/com/project/sns/controller/SearchController.java
@@ -1,0 +1,26 @@
+package com.project.sns.controller;
+
+import com.project.common.elasticsearch.UserDocument;
+import com.project.sns.service.SearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/auth/search")
+public class SearchController {
+
+    private final SearchService searchService;
+
+    //유저 검색어 입력
+    @GetMapping("/user")
+    public List<UserDocument> searchUsers(@RequestParam("keyword") String keyword) throws IOException {
+        return searchService.searchUsers(keyword);
+    }
+}

--- a/sns-service/src/main/java/com/project/sns/service/IndexAdminService.java
+++ b/sns-service/src/main/java/com/project/sns/service/IndexAdminService.java
@@ -1,0 +1,89 @@
+package com.project.sns.service;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class IndexAdminService {
+
+    private final RestClient restClient;
+
+    //유저 검색 커스터마이징
+    public void createUsersIndex() throws IOException {
+        String body = """
+        {
+          "settings": {
+            "index": {
+              "max_ngram_diff": 18
+            },
+            "analysis": {
+              "analyzer": {
+                "edge_ngram_analyzer": {
+                  "type": "custom",
+                  "tokenizer": "edge_ngram_tokenizer",
+                  "filter": ["lowercase"]
+                },
+                "ngram_analyzer": {
+                  "type": "custom",
+                  "tokenizer": "ngram_tokenizer",
+                  "filter": ["lowercase"]
+                }
+              },
+              "tokenizer": {
+                "edge_ngram_tokenizer": {
+                  "type": "edge_ngram",
+                  "min_gram": 1,
+                  "max_gram": 20,
+                  "token_chars": ["letter", "digit", "whitespace"]
+                },
+                "ngram_tokenizer": {
+                  "type": "ngram",
+                  "min_gram": 2,
+                  "max_gram": 20,
+                  "token_chars": ["letter", "digit", "whitespace"]
+                }
+              }
+            }
+          },
+          "mappings": {
+            "properties": {
+              "id": { "type": "long" },
+              "username": {
+                "type": "text",
+                "fields": {
+                  "edge": {
+                    "type": "text",
+                    "analyzer": "edge_ngram_analyzer",
+                    "search_analyzer": "standard"
+                  },
+                  "ngram": {
+                    "type": "text",
+                    "analyzer": "ngram_analyzer",
+                    "search_analyzer": "standard"
+                  },
+                  "standard": {
+                    "type": "text",
+                    "analyzer": "standard"
+                  }
+                }
+              },
+              "profileImage": { "type": "keyword" }
+            }
+          }
+        }
+        """;
+
+        Request request = new Request("PUT", "/users");
+        request.setEntity(new NStringEntity(body, ContentType.APPLICATION_JSON));
+        Response response = restClient.performRequest(request);
+        System.out.println("Elasticsearch users 인덱스 생성 결과: " + response.getStatusLine());
+    }
+}

--- a/sns-service/src/main/java/com/project/sns/service/SearchService.java
+++ b/sns-service/src/main/java/com/project/sns/service/SearchService.java
@@ -1,0 +1,52 @@
+package com.project.sns.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.project.common.elasticsearch.UserDocument;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final ElasticsearchClient elasticsearchClient;
+
+    // [유저 검색] 키워드를 기반으로 user 문서(users 인덱스)를 검색
+    public List<UserDocument> searchUsers(String keyword) throws IOException {
+        SearchResponse<UserDocument> response = elasticsearchClient.search(s -> s
+                        .index("users")         // 검색 대상 인덱스
+                        .size(50)               // 최대 검색 결과 개수
+                        .query(q -> q.bool(b -> b
+                                // edge ngram 기반: 접두어 자동완성
+                                .should(QueryBuilders.match(m -> m
+                                        .field("username.edge")
+                                        .query(keyword)
+                                        .boost(3.0f)))
+                                // 일반 ngram 기반: 중간 문자열 검색 가능
+                                .should(QueryBuilders.match(m -> m
+                                        .field("username.ngram")
+                                        .query(keyword)
+                                        .boost(2.0f)))
+                                // 표준 분석기로 오타 허용 검색
+                                .should(QueryBuilders.match(m -> m
+                                        .field("username.standard")
+                                        .query(keyword)
+                                        .fuzziness("AUTO")
+                                        .boost(1.0f)))
+                        )),
+                UserDocument.class
+        );
+
+        // 검색 결과에서 source (UserDocument)만 추출하여 리스트로 반환
+        return response.hits().hits().stream()
+                .map(Hit::source)
+                .collect(Collectors.toList());
+    }
+}

--- a/sns-service/src/main/resources/application.yml
+++ b/sns-service/src/main/resources/application.yml
@@ -30,6 +30,15 @@ spring:
         bucket: finsight-social-project
         profile-folder: team-project/profiles
 
+  elasticsearch:
+    repositories:
+      enabled: true
+    client:
+      reactive:
+        endpoints: localhost:9200
+    index:
+      auto-create: true
+
 app:
   # 배포시에는 배포 IP로 할당되도록 변경
   base-url: http://localhost:${server.port}


### PR DESCRIPTION
### 관련 이슈
- [033-User-Search]

### 작업 내용
1. `users` 인덱스를 수동 생성하기 위한 `IndexAdminService` 구현
2. 사용자 검색을 위한 analyzer/tokenizer 설정 적용
3. DB에 저장된 유저 정보를 Elasticsearch로 마이그레이션하는 기능 추가
4. edge_ngram / ngram / standard 기반 복합 검색 쿼리 구현

### 검색 동작 세부 설명

#### 인덱싱 시 토큰화 방식

- `edge_ngram_analyzer`: `"홍길동"` → `"홍"`, `"홍길"`, `"홍길동"`  
- `ngram_analyzer`: `"홍길동"` → `"홍길"`, `"길동"`  
- `standard`: `"홍길동"` 그대로 (오타 허용용)

#### 검색 시 전략

- `username.edge`: 접두어 자동완성 (`홍` → `홍길동`)
- `username.ngram`: 중간 문자열 검색 (`길` → `홍길동`)
- `username.standard`: 오타 허용 검색 (`홍깃동` → `홍길동`)
