### PR TITLE
feat: [035-Post-Feature] 게시글 CRUD 및 인기게시글 기능개발, 이미지 업로드는 S3 활용해 수정 예정

### DIFF
--- a/common/src/main/java/com/project/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/project/common/exception/ErrorCode.java
@@ -30,12 +30,14 @@ public enum ErrorCode {
   //채팅방 관련 예외
   NOT_FOUND_CHATROOM(HttpStatus.BAD_REQUEST, "존재하지 않는 채팅방입니다."),
 
-  //게시글 관련 예외
-  NOT_FOUND_POST(HttpStatus.BAD_REQUEST, "존재하지 않는 게시글입니다."),
-
   //리프레쉬토큰 및 로그아웃 관련 예외
   INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST,"리프레쉬토큰 발급을 위한 토큰이 존재하지 않습니다."),
-  REFRESH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "리프레쉬토큰이 만료되었습니다.");
+  REFRESH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "리프레쉬토큰이 만료되었습니다."),
+
+  // 게시글 관련 예외
+  NOT_FOUND_POST(HttpStatus.BAD_REQUEST,"게시글을 찾을 수 없습니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "이 작업을 수행할 권한이 없습니다.");
+
   private final HttpStatus httpStatus;
   private final String detail;
 }

--- a/sns-service/src/main/java/com/project/sns/application/PostApplication.java
+++ b/sns-service/src/main/java/com/project/sns/application/PostApplication.java
@@ -1,0 +1,299 @@
+package com.project.sns.application;
+
+import com.project.sns.entity.Post;
+import com.project.sns.entity.PostStats;
+import com.project.sns.dto.PostRequest;
+import com.project.sns.dto.PostResponse;
+import com.project.sns.repository.PostRepository;
+import com.project.sns.repository.PostStatsRepository;
+import com.project.sns.service.PostService;
+import com.project.common.exception.CustomException;
+import com.project.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.*;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PostApplication implements PostService {
+
+  private final PostRepository postRepository;
+  private final PostStatsRepository postStatsRepository;
+  private final StringRedisTemplate redisTemplate;
+
+  @Value("${app.redis.trending-key:post:views}")
+  private String REDIS_TRENDING_KEY;
+
+  /** 각 가중치 값을 상수로 정의함 */
+  private static final double WEIGHT_VIEW         = 0.5;   // 조회수
+  private static final double WEIGHT_LIKE         = 3.0;   // 좋아요
+  private static final double WEIGHT_COMMENT      = 2.0;   // 댓글
+  private static final double WEIGHT_UNDER_COMMENT= 1.0;   // 대댓글
+
+  /** 인기게시글 점수를 계산하는 메서드 부분 */
+  private double calculateScore(PostStats stats) {
+    return stats.getViewCount() * WEIGHT_VIEW
+        + stats.getLikeCount() * WEIGHT_LIKE
+        + stats.getCommentCount() * WEIGHT_COMMENT
+        + stats.getUnderCommentCount() * WEIGHT_UNDER_COMMENT;
+  }
+
+
+  @Override
+  @Transactional
+  public PostResponse createPost(PostRequest request) {
+    Post post = Post.builder()
+        .userId(request.getUserId())
+        .title(request.getTitle())
+        .content(request.getContent())
+        .postImageUrl(request.getPostImageUrl())
+        .build();
+
+    PostStats stats = PostStats.builder()
+        .post(post)
+        .likeCount(0)
+        .commentCount(0)
+        .viewCount(0)
+        .underCommentCount(0)
+        .build();
+
+    post.setPostStats(stats);
+    Post saved = postRepository.save(post);
+
+    // 게시글 생성 시, 점수는 0으로 ZSet에 점수 추가부분
+    redisTemplate.opsForZSet()
+        .add(REDIS_TRENDING_KEY, saved.getPostId().toString(), 0.0);
+
+
+    return toDto(saved, stats);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public PostResponse getPost(Long postId) {
+    // 조회 시 recordView 메서드 호출 조회수 증가 + 점수 재계산
+    recordView(postId);
+
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
+
+    PostStats stats = postStatsRepository.findByPostPostId(postId);
+    if (stats == null) {
+      throw new CustomException(ErrorCode.NOT_FOUND_POST);
+    }
+    return toDto(post, stats);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Page<PostResponse> getAllPosts(Pageable pageable) {
+    Page<Post> page = postRepository.findAll(
+        PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+            Sort.by("createdAt").descending())
+    );
+    List<PostResponse> dtos = page.stream()
+        .map(p -> {
+          PostStats stats = postStatsRepository.findByPostPostId(p.getPostId());
+          if (stats == null) {
+            throw new CustomException(ErrorCode.NOT_FOUND_POST);
+          }
+          return toDto(p, stats);
+        })
+        .collect(Collectors.toList());
+    return new PageImpl<>(dtos, pageable, page.getTotalElements());
+  }
+
+  @Override
+  @Transactional
+  public PostResponse updatePost(Long postId, PostRequest request) {
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
+
+    post.update(request.getTitle(), request.getContent(), request.getPostImageUrl());
+    postRepository.save(post);
+
+    PostStats stats = postStatsRepository.findByPostPostId(postId);
+    if (stats == null) {
+      throw new CustomException(ErrorCode.NOT_FOUND_POST);
+    }
+
+    // 수정시에 점수를 어떻게 할지 고민중입니다. 저의 회의 후에 결정하겠습니다.
+    // 점수는 변경되지 않아서 ZSet 재갱신이 필요 없지만
+    // 만약에 다른 값으로 변경한다면 여기서 calculateScore(stats)를 다시 호출하여 ZSet 갱신!
+
+    return toDto(post, stats);
+  }
+
+  @Override
+  @Transactional
+  public void deletePost(Long postId, Long userId) {
+
+    Post post = postRepository.findById(postId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
+
+    //작성자 일치 검증
+    if (!post.getUserId().equals(userId)) {
+      throw new CustomException(ErrorCode.FORBIDDEN);  // ErrorCode에 FORBIDDEN 추가 필요
+    }
+
+    //Cascade 설정 으로 연관된 댓글,좋아요,PostStats 모두 삭제됨
+    postRepository.delete(post);
+
+    //Redis ZSet 에서도 인기 점수 제거
+    redisTemplate.opsForZSet().remove(REDIS_TRENDING_KEY, postId.toString());
+  }
+
+  @Override
+  @Transactional
+  public void recordView(Long postId) {
+
+    PostStats stats = postStatsRepository.findByPostPostId(postId);
+    if (stats == null) {
+      throw new CustomException(ErrorCode.NOT_FOUND_POST);
+    }
+    stats.incrementView();
+    postStatsRepository.save(stats);
+
+    Post post = stats.getPost();
+    post.setViews(stats.getViewCount());
+    postRepository.save(post);
+
+    // 가중치 기반 점수 재계산 -> ZSet 갱신
+    double newScore = calculateScore(stats);
+    redisTemplate.opsForZSet()
+        .add(REDIS_TRENDING_KEY, postId.toString(), newScore);
+  }
+
+  /** 좋아요 발생 시 호출 */
+  @Transactional
+  public void recordLike(Long postId) {
+    PostStats stats = postStatsRepository.findByPostPostId(postId);
+    if (stats == null) {
+      throw new CustomException(ErrorCode.NOT_FOUND_POST);
+    }
+    stats.incrementLike();
+    postStatsRepository.save(stats);
+
+    double newScore = calculateScore(stats);
+    redisTemplate.opsForZSet()
+        .add(REDIS_TRENDING_KEY, postId.toString(), newScore);
+  }
+
+  @Transactional
+  public void recordUnlike(Long postId) {
+    PostStats stats = postStatsRepository.findByPostPostId(postId);
+    if (stats == null) {
+      throw new CustomException(ErrorCode.NOT_FOUND_POST);
+    }
+    // 좋아요 개수 1 감소
+    stats.setLikeCount(stats.getLikeCount() - 1);
+    postStatsRepository.save(stats);
+
+    // 복합 점수 재계산 → Redis ZSet 갱신
+    double newScore = calculateScore(stats);
+    redisTemplate.opsForZSet().add(REDIS_TRENDING_KEY, postId.toString(), newScore);
+  }
+
+  /** 댓글 발생 시 호출 */
+  @Transactional
+  public void recordComment(Long postId) {
+    PostStats stats = postStatsRepository.findByPostPostId(postId);
+    if (stats == null) {
+      throw new CustomException(ErrorCode.NOT_FOUND_POST);
+    }
+    stats.incrementComment();
+    postStatsRepository.save(stats);
+
+    double newScore = calculateScore(stats);
+    redisTemplate.opsForZSet()
+        .add(REDIS_TRENDING_KEY, postId.toString(), newScore);
+  }
+  /** 댓글 삭제 시 호출 */
+  @Transactional
+  public void recordCommentRemoval(Long postId) {
+    PostStats stats = postStatsRepository.findByPostPostId(postId);
+    if (stats == null) {
+      throw new CustomException(ErrorCode.NOT_FOUND_POST);
+    }
+    // commentCount를 1 줄이되, 음수로 떨어지지 않게
+    int newCommentCount = Math.max(stats.getCommentCount() - 1, 0);
+    stats.setCommentCount(newCommentCount);
+    postStatsRepository.save(stats);
+
+    double newScore = calculateScore(stats);   // (가중치 계산)
+    redisTemplate.opsForZSet().add(REDIS_TRENDING_KEY, postId.toString(), newScore);
+  }
+
+
+  @Override
+  @Transactional(readOnly = true)
+  public Page<PostResponse> getTrendingPosts(Pageable pageable) {
+    ZSetOperations<String, String> zset = redisTemplate.opsForZSet();
+    long start = pageable.getPageNumber() * pageable.getPageSize();
+    long end   = start + pageable.getPageSize() - 1;
+
+    // 1) Redis에서 점수 순으로 postId 범위 조회
+    Set<ZSetOperations.TypedTuple<String>> tuples =
+        zset.reverseRangeWithScores(REDIS_TRENDING_KEY, start, end);
+
+    if (tuples == null || tuples.isEmpty()) {
+      return new PageImpl<>(Collections.emptyList(), pageable, 0);
+    }
+
+    // 2) postId 문자열 -> Long 리스트로 변환
+    List<Long> postIds = tuples.stream()
+        .map(tuple -> Long.valueOf(tuple.getValue()))
+        .collect(Collectors.toList());
+
+    // 3) DB에서 해당 postId들을 한 번에 조회
+    List<Post> posts = postRepository.findAllById(postIds);
+
+    // 4) Map<postId, Post> 생성(정렬 순서 유지를 위해)
+    Map<Long, Post> postMap = posts.stream()
+        .collect(Collectors.toMap(Post::getPostId, p -> p));
+
+    // 5) postId 순서대로 DTO 생성
+    List<PostResponse> dtos = new ArrayList<>();
+    for (Long pid : postIds) {
+      Post p = postMap.get(pid);
+      if (p == null) continue;
+      PostStats stats = postStatsRepository.findByPostPostId(pid);
+      if (stats == null) {
+        throw new CustomException(ErrorCode.NOT_FOUND_POST);
+      }
+      dtos.add(toDto(p, stats));
+    }
+
+    // 6) 전체 인기 게시글 수 (ZSet 전체 원소 개수)
+    Long total = zset.zCard(REDIS_TRENDING_KEY);
+    return new PageImpl<>(dtos, pageable, (total != null ? total : 0));
+  }
+
+  /**
+   * Post + PostStats -> PostResponse DTO 변환
+   * */
+  private PostResponse toDto(Post post, PostStats stats) {
+    return PostResponse.builder()
+        .postId(post.getPostId())
+        .userId(post.getUserId())
+        .title(post.getTitle())
+        .content(post.getContent())
+        .postImageUrl(post.getPostImageUrl())
+        .createdAt(post.getCreatedAt())
+        .updatedAt(post.getUpdatedAt())
+        .views(post.getViews())
+        .likeCount(stats.getLikeCount())
+        .commentCount(stats.getCommentCount())
+        .underCommentCount(stats.getUnderCommentCount())
+        .build();
+  }
+}
+
+

--- a/sns-service/src/main/java/com/project/sns/controller/PostController.java
+++ b/sns-service/src/main/java/com/project/sns/controller/PostController.java
@@ -1,0 +1,100 @@
+package com.project.sns.controller;
+
+import com.project.common.UserVo;
+import com.project.sns.dto.PostRequest;
+import com.project.sns.dto.PostResponse;
+import com.project.sns.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+public class PostController {
+
+  private final PostService postService;
+
+  /**
+   * 게시글 생성 POST /posts
+   */
+  @PostMapping
+  public ResponseEntity<PostResponse> createPost(
+      @RequestBody PostRequest request,
+      @AuthenticationPrincipal UserVo userVo
+  ) {
+    // JWT 인증을 통해 SecurityContext 에 저장된 UserVo 로 userId 취득
+    Long userId = userVo.getId();
+    request.setUserId(userId);
+
+    PostResponse response = postService.createPost(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  /**
+   * 게시글 하나씩 조회 (조회수 증가 및 인기집계 반영)
+   */
+  @GetMapping("/{postId}")
+  public ResponseEntity<PostResponse> getPost(
+      @PathVariable Long postId
+  ) {
+    PostResponse response = postService.getPost(postId);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 게시글 페이징 조회 (최신순)
+   */
+  @GetMapping
+  public ResponseEntity<Page<PostResponse>> getAllPosts(
+      Pageable pageable
+  ) {
+    Page<PostResponse> page = postService.getAllPosts(pageable);
+    return ResponseEntity.ok(page);
+  }
+
+  /**
+   * 게시글 수정
+   */
+  @PutMapping("/{postId}")
+  public ResponseEntity<PostResponse> updatePost(
+      @PathVariable Long postId,
+      @RequestBody PostRequest request,
+      @AuthenticationPrincipal UserVo userVo
+  ) {
+    Long userId = userVo.getId();
+    request.setUserId(userId);
+
+    PostResponse response = postService.updatePost(postId, request);
+    return ResponseEntity.ok(response);
+  }
+
+  /**
+   * 게시글 삭제 (작성자만 삭제 가능)
+   */
+  @DeleteMapping("/{postId}")
+  public ResponseEntity<Void> deletePost(
+      @PathVariable Long postId,
+      @AuthenticationPrincipal UserVo userVo
+  ) {
+    Long userId = userVo.getId();
+    postService.deletePost(postId, userId);
+    return ResponseEntity.noContent().build();
+  }
+
+
+  /**
+   * 인기 게시글 조회 (가중치 기반, 페이징처리)
+   */
+  @GetMapping("/trending")
+  public ResponseEntity<Page<PostResponse>> getTrendingPosts(
+      Pageable pageable
+  ) {
+    Page<PostResponse> page = postService.getTrendingPosts(pageable);
+    return ResponseEntity.ok(page);
+  }
+}

--- a/sns-service/src/main/java/com/project/sns/dto/PostRequest.java
+++ b/sns-service/src/main/java/com/project/sns/dto/PostRequest.java
@@ -1,0 +1,25 @@
+package com.project.sns.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostRequest {
+  @NotNull
+  private Long userId;
+
+  @NotBlank
+  @Size(max = 255)
+  private String title;
+
+  @NotBlank
+  private String content;
+
+  private String postImageUrl;
+}

--- a/sns-service/src/main/java/com/project/sns/dto/PostResponse.java
+++ b/sns-service/src/main/java/com/project/sns/dto/PostResponse.java
@@ -1,0 +1,25 @@
+package com.project.sns.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostResponse {
+  private Long postId;
+  private Long userId;
+  private String title;
+  private String content;
+  private String postImageUrl;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private Integer views;
+  private Integer likeCount;
+  private Integer commentCount;
+  private Integer underCommentCount;
+}
+

--- a/sns-service/src/main/java/com/project/sns/entity/Like.java
+++ b/sns-service/src/main/java/com/project/sns/entity/Like.java
@@ -11,11 +11,13 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Table(name = "likes")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Like {
     @Id
+    @Column(name = "like_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long likeId;
 

--- a/sns-service/src/main/java/com/project/sns/entity/Post.java
+++ b/sns-service/src/main/java/com/project/sns/entity/Post.java
@@ -1,14 +1,77 @@
 package com.project.sns.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Entity
+@Table(name = "posts")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)  // JPA 스펙 때문에 기본 생성자는 protected로 둠
+@AllArgsConstructor
+@Builder
 public class Post {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long postId;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "post_id")
+  private Long postId;
+
+  @Column(name = "user_id", nullable = false)
+  private Long userId;
+
+  @Column(name = "title", nullable = false)
+  private String title;
+
+  @Lob   // TEXT 타입으로 매핑
+  @Column(name = "content", nullable = false)
+  private String content;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Column(name = "views", nullable = false, columnDefinition = "integer default 0")
+  private Integer views;
+
+  @Column(name = "post_image_url")
+  private String postImageUrl;
+
+  @OneToOne(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+  private PostStats postStats;
+
+  // 댓글 매핑
+  @OneToMany(
+      mappedBy = "post",
+      cascade = CascadeType.REMOVE,   // Post 삭제 시 댓글도 함께 삭제
+      orphanRemoval = true,           // 연관관계 제거 시 해당 자식 엔티티도 삭제
+      fetch = FetchType.LAZY
+  )
+  private List<Comment> comments = new ArrayList<>();
+
+  // 게시글 좋아요 매핑
+  @OneToMany(
+      mappedBy = "post",
+      cascade = CascadeType.REMOVE,
+      orphanRemoval = true,
+      fetch = FetchType.LAZY
+  )
+  private List<Like> likes = new ArrayList<>();
+
+  public void update(String newTitle, String newContent, String newImageUrl) {
+    this.title = newTitle;
+    this.content = newContent;
+    this.postImageUrl = newImageUrl;
+  }
 }
+

--- a/sns-service/src/main/java/com/project/sns/entity/PostStats.java
+++ b/sns-service/src/main/java/com/project/sns/entity/PostStats.java
@@ -1,0 +1,68 @@
+package com.project.sns.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 게시글 통계(PostStats) 엔티티
+ * • ERD 상에서 조회용 게시글 가중치 스탯 테이블(PostStats)과 1대1 매핑
+ * • 좋아요 수, 댓글 수, 조회 수, 대댓글 수 등을 관리
+ * • Post 엔티티와 1:1 관계를 맺고, FK(post_id)를 PostStats가 관리
+ */
+@Entity
+@Table(name = "poststats")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class PostStats {
+
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "poststats_id")
+  private Long postStatsId;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id", nullable = false, unique = true)
+  private Post post;
+
+  @Column(name = "like_count", nullable = false, columnDefinition = "integer default 0")
+  private Integer likeCount;
+
+  @Column(name = "comment_count", nullable = false, columnDefinition = "integer default 0")
+  private Integer commentCount;
+
+  /**
+   * 조회 수 (실시간 집계할 때 Redis에서 읽어와 DB에 동기화하거나 recordView 메서드 호출 시 증가)
+   */
+  @Column(name = "view_count", nullable = false, columnDefinition = "integer default 0")
+  private Integer viewCount;
+
+  /**
+   * 대댓글(하위 댓글) 수
+   */
+  @Column(name = "under_comment_count", nullable = false, columnDefinition = "integer default 0")
+  private Integer underCommentCount;
+
+  //===========================================================
+  // 아래부터는 값을 증가시키기 위한 가중치 메서드들이고 호출 시에, 카운트를 1씩 증가하게 구현했습니다.
+  //===========================================================
+
+  public void incrementLike() {
+    this.likeCount = this.likeCount + 1;
+  }
+
+  public void incrementComment() {
+    this.commentCount = this.commentCount + 1;
+  }
+
+  public void incrementView() {
+    this.viewCount = this.viewCount + 1;
+  }
+
+  public void incrementUnderComment() {
+    this.underCommentCount = this.underCommentCount + 1;
+  }
+}

--- a/sns-service/src/main/java/com/project/sns/repository/PostRepository.java
+++ b/sns-service/src/main/java/com/project/sns/repository/PostRepository.java
@@ -1,9 +1,12 @@
 package com.project.sns.repository;
 
 import com.project.sns.entity.Post;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+  List<Post> findALlByUserId(Long userId);
 }

--- a/sns-service/src/main/java/com/project/sns/repository/PostStatsRepository.java
+++ b/sns-service/src/main/java/com/project/sns/repository/PostStatsRepository.java
@@ -1,0 +1,10 @@
+package com.project.sns.repository;
+
+import com.project.sns.entity.PostStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostStatsRepository extends JpaRepository<PostStats, Long> {
+
+  PostStats findByPostPostId(Long postId);
+
+}

--- a/sns-service/src/main/java/com/project/sns/service/CommentService.java
+++ b/sns-service/src/main/java/com/project/sns/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.project.sns.service;
 
+import com.project.sns.application.PostApplication;
 import com.project.sns.controller.NotificationSocketController;
 import com.project.sns.dto.CommentRequestDto;
 import com.project.sns.dto.CommentResponseDto;
@@ -30,6 +31,8 @@ public class CommentService {
   private final NotificationRepository notificationRepository;
   private final NotificationSocketController notificationSocketController;
   private final CommentLikeRepository commentLikeRepository;
+  private final PostApplication postApplication;
+
 
   /**
    * 댓글 또는 대댓글을 생성합니다.
@@ -49,6 +52,8 @@ public class CommentService {
 
     // 댓글 저장
     commentRepository.save(comment);
+    // 댓글 점수 갱신(인기게시글)
+    postApplication.recordComment(postId);
 
     // WebSocket 실시간 알림 전송
     Long postWriterId = 2L; // TODO: 실제 게시글 작성자의 ID로 변경 필요

--- a/sns-service/src/main/java/com/project/sns/service/PostLikeService.java
+++ b/sns-service/src/main/java/com/project/sns/service/PostLikeService.java
@@ -1,19 +1,17 @@
 package com.project.sns.service;
 
-import com.project.common.dto.UserSummaryDto;
 import com.project.common.exception.CustomException;
 import com.project.common.exception.ErrorCode;
-import com.project.sns.client.UserClient;
+import com.project.sns.application.PostApplication;
 import com.project.sns.entity.Like;
 import com.project.sns.entity.Post;
 import com.project.sns.repository.PostLikeRepository;
 import com.project.sns.repository.PostRepository;
+import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +19,7 @@ public class PostLikeService {
 
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
+    private final PostApplication postApplication;
 
     // 게시글 좋아요 처리(토글 형식)
     @Transactional
@@ -35,6 +34,7 @@ public class PostLikeService {
         if (existingLike.isPresent()) {
             postLikeRepository.delete(existingLike.get());
             isLiked = false;
+            postApplication.recordUnlike(postId);
         } else {
             Like like = Like.builder()
                     .post(post)
@@ -42,6 +42,7 @@ public class PostLikeService {
                     .build();
             postLikeRepository.save(like);
             isLiked = true;
+            postApplication.recordLike(postId);
         }
 
         long likeCount = postLikeRepository.countByPost(post);

--- a/sns-service/src/main/java/com/project/sns/service/PostService.java
+++ b/sns-service/src/main/java/com/project/sns/service/PostService.java
@@ -1,0 +1,20 @@
+package com.project.sns.service;
+
+import com.project.sns.dto.PostRequest;
+import com.project.sns.dto.PostResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface PostService {
+
+  PostResponse createPost(PostRequest postRequest);
+  PostResponse getPost(Long postId);
+  Page<PostResponse> getAllPosts(Pageable pageable);
+  PostResponse updatePost(Long postId, PostRequest request);
+  void deletePost(Long postId, Long userId);
+  void recordView(Long postId);
+  Page<PostResponse> getTrendingPosts(Pageable pageable);
+
+}


### PR DESCRIPTION
Changes
---
- Post, PostStats 엔티티 및 Cascade 설정으로 연관된 댓글/좋아요 자동 삭제 적용
- PostApplication 서비스에 CRUD(생성·조회·수정·삭제) 및 인기집계(조회수/좋아요/댓글/대댓글 가중치 기반) 로직 구현
- getPost 호출 시 recordView로 조회수 증가 및 Redis ZSet 점수 갱신
- getAllPosts로 최신순 페이징 조회, getTrendingPosts로 Redis ZSet 기반 인기 게시글 페이징 조회 기능 추가
- deletePost 메서드에 작성자(UserVo) 권한 검증 로직 반영
- PostController에 REST 엔드포인트 매핑 완료 (생성, 조회, 전체조회, 수정, 삭제, 인기조회)
- JWT 인증(UserVo) 적용 후 create/update/delete 시 userId 자동 주입
- 현재 postImageUrl 필드에 클라이언트에서 전달된 URL을 그대로 저장, MultipartFile -> S3 업로드 로직은 추후 통합 작업 예정
---
- like 예약어 오류로 Like 엔티티 테이블명 수정